### PR TITLE
Replaced database shutdown with checkpoint for backup

### DIFF
--- a/core/src/main/java/com/ebner/roomdatabasebackup/core/RoomBackup.kt
+++ b/core/src/main/java/com/ebner/roomdatabasebackup/core/RoomBackup.kt
@@ -287,7 +287,8 @@ class RoomBackup {
         if (!success) return
 
         //Close the database
-        roomDatabase!!.close()
+        // roomDatabase!!.close()
+        roomDatabase!!.query(SimpleSQLiteQuery("pragma wal_checkpoint(full)"))
 
         //Create name for backup file, if no custom name is set: Database name + currentTime + .sqlite3
         var filename = if (customBackupFileName == null) "$dbName-${getTime()}.sqlite3" else customBackupFileName as String


### PR DESCRIPTION
This way there is no need to restart the app after backup so it can be used seamlessly - for automatic daily backups, for example.