### PR TITLE
fixed SDK33 permission denied error.

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -2,8 +2,16 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:ignore="ExtraText">
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <!-- Required only if your app targets Android 13. -->
+    <!-- Declare one or more the following permissions only if your app needs
+    to access data thats protected by them. -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
+
+    <!-- Required to maintain app compatibility. -->
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
+        android:maxSdkVersion="32" />
 
     /
 </manifest>

--- a/core/src/main/java/de/raphaelebner/roomdatabasebackup/core/RoomBackup.kt
+++ b/core/src/main/java/de/raphaelebner/roomdatabasebackup/core/RoomBackup.kt
@@ -1,7 +1,6 @@
 package de.raphaelebner.roomdatabasebackup.core
 
-import android.Manifest.permission.READ_EXTERNAL_STORAGE
-import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
+import android.Manifest.permission.*
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
@@ -369,7 +368,11 @@ class RoomBackup(var context: Context) : FragmentActivity() {
             }
             BACKUP_FILE_LOCATION_CUSTOM_DIALOG -> {
                 backupFilename = filename
-                permissionRequestLauncher.launch(arrayOf(WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE))
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    permissionRequestLauncher.launch(arrayOf(READ_MEDIA_IMAGES, READ_MEDIA_AUDIO, READ_MEDIA_VIDEO))
+                } else {
+                    permissionRequestLauncher.launch(arrayOf(WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE))
+                }
                 return
             }
             BACKUP_FILE_LOCATION_CUSTOM_FILE -> {
@@ -497,7 +500,11 @@ class RoomBackup(var context: Context) : FragmentActivity() {
                 backupDirectory = File("$EXTERNAL_BACKUP_PATH/")
             }
             BACKUP_FILE_LOCATION_CUSTOM_DIALOG -> {
-                permissionRequestLauncher.launch(arrayOf(WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE))
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    permissionRequestLauncher.launch(arrayOf(READ_MEDIA_IMAGES, READ_MEDIA_AUDIO, READ_MEDIA_VIDEO))
+                } else {
+                    permissionRequestLauncher.launch(arrayOf(WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE))
+                }
                 return
             }
             BACKUP_FILE_LOCATION_CUSTOM_FILE -> {

--- a/core/src/main/java/de/raphaelebner/roomdatabasebackup/core/RoomBackup.kt
+++ b/core/src/main/java/de/raphaelebner/roomdatabasebackup/core/RoomBackup.kt
@@ -371,7 +371,7 @@ class RoomBackup(var context: Context) : FragmentActivity() {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     permissionRequestLauncher.launch(arrayOf(READ_MEDIA_IMAGES, READ_MEDIA_AUDIO, READ_MEDIA_VIDEO))
                 } else {
-                    permissionRequestLauncher.launch(arrayOf(WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE))
+                    permissionRequestLauncher.launch(arrayOf(READ_EXTERNAL_STORAGE))
                 }
                 return
             }
@@ -503,7 +503,7 @@ class RoomBackup(var context: Context) : FragmentActivity() {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                     permissionRequestLauncher.launch(arrayOf(READ_MEDIA_IMAGES, READ_MEDIA_AUDIO, READ_MEDIA_VIDEO))
                 } else {
-                    permissionRequestLauncher.launch(arrayOf(WRITE_EXTERNAL_STORAGE, READ_EXTERNAL_STORAGE))
+                    permissionRequestLauncher.launch(arrayOf(READ_EXTERNAL_STORAGE))
                 }
                 return
             }


### PR DESCRIPTION
In previous versions, there was an error in the code to obtain permissions in sdk33. Through branching processing, SDK 33 or higher devices have been processed to store and recover using external dialogs.