### PR TITLE
Fix backup restore issue & UI layout fix for sample app on Android 15 (#39)

### DIFF
--- a/app/src/main/res/layout/activity_add_edit_fruit.xml
+++ b/app/src/main/res/layout/activity_add_edit_fruit.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:orientation="vertical"
     android:padding="16dp"
     tools:context="de.raphaelebner.roomdatabasebackup.sample.ActivityAddEditFruit">

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -5,6 +5,7 @@
     android:id="@+id/cl_main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     android:paddingBottom="16dp"
     tools:ignore="HardcodedText"
     tools:context=".MainActivity">

--- a/core/src/main/java/de/raphaelebner/roomdatabasebackup/core/RoomBackup.kt
+++ b/core/src/main/java/de/raphaelebner/roomdatabasebackup/core/RoomBackup.kt
@@ -721,7 +721,7 @@ class RoomBackup(var context: Context) {
                         openBackupfileCreator.launch(backupFilename)
                     }
                     PROCESS_RESTORE -> {
-                        openBackupfileChooser.launch(arrayOf("application/octet-stream"))
+                        openBackupfileChooser.launch(arrayOf("application/octet-stream", "application/vnd.sqlite3"))
                     }
                 }
             }


### PR DESCRIPTION
This PR fixes two issues encountered on Android 15:
-  `.sqlite3` files were not being detected when selecting a backup for restore (#39).
- UI elements hidden behind the toolbar in the sample app.
