### PR TITLE
Fix empty backup file when saving to Google Drive (#18)

### DIFF
--- a/core/src/main/java/de/raphaelebner/roomdatabasebackup/core/RoomBackup.kt
+++ b/core/src/main/java/de/raphaelebner/roomdatabasebackup/core/RoomBackup.kt
@@ -417,13 +417,19 @@ class RoomBackup(var context: Context) {
         // Close the database
         roomDatabase!!.close()
         roomDatabase = null
+
+        val bos = BufferedOutputStream(destination)
         if (backupIsEncrypted) {
             val encryptedBytes = encryptBackup() ?: return
-            destination.write(encryptedBytes)
+            bos.write(encryptedBytes)
         } else {
             // Copy current database to save location (/files dir)
-            copy(DATABASE_FILE, destination)
+            val inputStream = DATABASE_FILE.inputStream().buffered()
+            inputStream.copyTo(bos)
+            inputStream.close()
         }
+        bos.flush()
+        bos.close()
 
         // If maxFileCount is set and is reached, delete oldest file
         if (maxFileCount != null) {


### PR DESCRIPTION
This PR fixes the issue where backups saved to Google Drive resulted in empty files (0 KB) (#18)

https://github.com/user-attachments/assets/51b5ebd0-c4bf-4bab-9756-dab4c0442fcc

Tested on vivo V30 (Android 15) and Emulator Pixel 3 API 29